### PR TITLE
[Tripcourse, fix] 메인화면 카드 중첩 에러 수정, Trip 삭제 기능 추가, Tripcourse 수정 기능 추가(아직 수정은 불가)

### DIFF
--- a/app/src/main/java/com/olympos/tripbook/src/home/MainActivity.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/home/MainActivity.kt
@@ -20,10 +20,11 @@ import com.olympos.tripbook.src.home.model.HomeService
 import com.olympos.tripbook.src.splash.SplashActivity
 import com.olympos.tripbook.src.trip.TripActivity
 import com.olympos.tripbook.src.tripcourse_view.TripcourseViewFragment
+import com.olympos.tripbook.src.user.model.UserView
 import com.olympos.tripbook.utils.*
 
 
-class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedListener, HomeGetProcess {
+class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedListener, HomeGetProcess, UserView {
     private lateinit var binding: ActivityMainBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -141,11 +142,11 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
         startSplashActivity()
     }
 
-    override fun onGetHomeLoading() {
+    override fun getTripCountLoading() {
         //todo
     }
 
-    override fun onGetHomeSuccess(result: Int) {
+    override fun getTripCountSuccess(result: Int) {
         binding.mainUserTripCountTv.text = result.toString()
 
         //기록이 0일 때
@@ -161,21 +162,74 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
         }
     }
 
-    override fun onGetHomeFailure(code: Int, message: String) {
+    override fun getTripCountFailure(code: Int, message: String) {
         when(code) {
             400 -> Toast.makeText(this, "네트워크 상태를 확인해주세요.", Toast.LENGTH_SHORT).show()
             2105 -> Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
         }
     }
 
+    override fun autoSigninSuccess() {
+        TODO("Not yet implemented")
+    }
 
-//    private fun initViewpager() {
-//        val tripVP = TripViewpagerAdapter(this)
-////        tripVP.addFragment(BannerFragment(R.drawable.img_home_viewpager_exp))
-//
-//        binding.mainContentVp.adapter = tripVP
-//        binding.mainContentVp.orientation = ViewPager2.ORIENTATION_HORIZONTAL
-//        binding.mainContentCi.setViewPager(binding.mainContentVp)
-//    }
+    override fun autoSigninFailure(code: Int) {
+        TODO("Not yet implemented")
+    }
 
+    override fun signUpUserSuccess() {
+        TODO("Not yet implemented")
+    }
+
+    override fun signUpUserFailure(code: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun signUpProfileSuccess() {
+        TODO("Not yet implemented")
+    }
+
+    override fun signUpProfileFailure(code: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun kakaoSigninSuccess() {
+        TODO("Not yet implemented")
+    }
+
+    override fun kakaoSigninFailure(code: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateKakaoAccessTokenSuccess() {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateKakaoAccessTokenFailure(code: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateProfileSuccess() {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateProfileFailure(code: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getProfileSuccess() {
+        TODO("Not yet implemented")
+    }
+
+    override fun getProfileFailure(code: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateAccessTokenSuccess() {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateAccessTokenFailure(code: Int) {
+        TODO("Not yet implemented")
+    }
 }

--- a/app/src/main/java/com/olympos/tripbook/src/home/model/HomeGetProcess.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/home/model/HomeGetProcess.kt
@@ -3,13 +3,7 @@ package com.olympos.tripbook.src.home.model
 import com.olympos.tripbook.src.tripcourse.model.Card
 
 interface HomeGetProcess {
-    fun onGetHomeLoading()
-    fun onGetHomeSuccess(result: Int)
-    fun onGetHomeFailure(code: Int, message: String)
-}
-
-interface CardsView {
-    fun onGetCardsLoading()
-    fun onGetCardsSuccess(cards : ArrayList<Card>)
-    fun onGetCardsFailure(code : Int, message : String)
+    fun getTripCountLoading()
+    fun getTripCountSuccess(result: Int)
+    fun getTripCountFailure(code: Int, message: String)
 }

--- a/app/src/main/java/com/olympos/tripbook/src/home/model/HomeRetrofitInterface.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/home/model/HomeRetrofitInterface.kt
@@ -6,7 +6,4 @@ import retrofit2.http.*
 interface HomeRetrofitInterface {
     @GET("/app/trips/count/{userIdx}")
     fun getTripCount(@Path("userIdx") userIdx: String): Call<HomeResponse>
-
-    @GET("/app/trip/{tripIdx}/courses")
-    fun getTrip(@Path("tripIdx") tripIdx : String) : Call<RecentTripResponse>
 }

--- a/app/src/main/java/com/olympos/tripbook/src/home/model/HomeService.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/home/model/HomeService.kt
@@ -12,18 +12,12 @@ class HomeService {
         this.process = process
     }
 
-    private lateinit var cardsView : CardsView
-
-    fun setCardsView(cardsView : CardsView) {
-        this.cardsView = cardsView
-    }
-
     fun getTripCount() {
         Log.d("들어오는지 확인", "HomeService-getTripCount")
         val homeRetrofitService = retrofit.create(HomeRetrofitInterface::class.java)
 
         //호출 전 loading
-        process.onGetHomeLoading()
+        process.getTripCountLoading()
 
         //api 호출 후 응답받으면 callback
         homeRetrofitService.getTripCount(getUserIdx().toString()).enqueue(object : Callback<HomeResponse> {
@@ -32,47 +26,15 @@ class HomeService {
                     val res = response.body()!!
                     Log.d("__res", response.body()!!.toString())
                     when (res.code) {
-                        1000 -> process.onGetHomeSuccess(res.result)
-                        else -> process.onGetHomeFailure(res.code, res.message)
+                        1000 -> process.getTripCountSuccess(res.result)
+                        else -> process.getTripCountFailure(res.code, res.message)
                     }
                 }
             }
 
             //네트워크 실패
             override fun onFailure(call: Call<HomeResponse>, t: Throwable) {
-                process.onGetHomeFailure(400, t.message.toString())
-            }
-        })
-    }
-
-    //여행 가져오기
-    fun getTrip(tripIdx : String){
-        val homeRetrofitService = retrofit.create(HomeRetrofitInterface::class.java)
-
-        cardsView.onGetCardsLoading()
-
-        homeRetrofitService.getTrip(tripIdx).enqueue(object : Callback<RecentTripResponse> {
-            override fun onResponse(call: Call<RecentTripResponse>, response: Response<RecentTripResponse>) {
-                Log.d("들어오는지 확인", "HomeService-getTrip-onResponse")
-                if (response.isSuccessful) {
-                    val res = response.body()!!
-                    Log.d("__res", response.body()!!.toString())
-                    when (res.code) {
-                        1000 -> {
-                            Log.d("REST API TEST 성공", res.toString())
-                            cardsView.onGetCardsSuccess(res.result)
-                        }
-
-                        else -> {
-                            Log.d("통신 실패 : ", res.toString())
-                            cardsView.onGetCardsFailure(res.code, res.message)
-                        }
-                    }
-                }
-            }
-            override fun onFailure(call: Call<RecentTripResponse>, t: Throwable) {
-                Log.d("들어오는지 확인", "CardService-getTrip-onFailure")
-                cardsView.onGetCardsFailure(400, t.message.toString())
+                process.getTripCountFailure(400, t.message.toString())
             }
         })
     }

--- a/app/src/main/java/com/olympos/tripbook/src/tripcourse/RVCardAdapter.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/tripcourse/RVCardAdapter.kt
@@ -67,6 +67,7 @@ class RVCardAdapter(context : Context) : RecyclerView.Adapter<RecyclerView.ViewH
             if(card.imgUrl == "NONE"){
                 binding.itemCardFillCoverImg.setImageResource(R.drawable.img_tripcourse_card_ex)
             } else {
+                //todo download Firebase Img
                 Glide.with(mContext).load(card.imgUrl).into(binding.itemCardFillCoverImg) //context 인자로 받아와야 함
             }
 

--- a/app/src/main/java/com/olympos/tripbook/src/tripcourse/TripcourseActivity.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/tripcourse/TripcourseActivity.kt
@@ -36,9 +36,10 @@ class TripcourseActivity : BaseActivity(), PostCardView, ServerView {
         binding = ActivityTripcourseBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        initView()
         initRecyclerView()
-        addDefaultCard()
+        initView()
+
+
     }
 
     @SuppressLint("NotifyDataSetChanged")
@@ -63,8 +64,23 @@ class TripcourseActivity : BaseActivity(), PostCardView, ServerView {
         tripData = gson.fromJson(intent.getStringExtra("tripData"), Trip::class.java)
         //여행 정보 가져옴
         tripIdx = getTripIdx()
-
         Log.d("Tripcourse_tripIdx/Data", "tripIdx : $tripIdx, tripData : $tripData")
+
+        //tripcouse 정보
+        val cards : Array<Card>? = gson.fromJson(intent.getStringExtra("tripcourseData"), Array<Card>::class.java)
+
+        if( cards == null ) {
+            setDefaultCard()
+        } else {
+            tripCards.clear()
+            var i = 0
+            while( i < cards.size ) {
+                if(cards[i].title != "NONE")
+                    cards[i].hasData = TRUE
+                tripCards.add(cards[i])
+                i++
+            }
+        }
 
         //출발일
         val dDate = tripData.departureDate.split("-")
@@ -99,6 +115,13 @@ class TripcourseActivity : BaseActivity(), PostCardView, ServerView {
         registerForContextMenu(binding.tripcourseTitlebarLayout)
     }
 
+    override fun onBackPressed() {
+        showDialog(
+            "발자국 작성 취소", "발자국 작성을 취소하시겠습니까?\n"
+                    + "작성중인 정보는 저장되지 않습니다.", "확인"
+        )
+    }
+
     @SuppressLint("NotifyDataSetChanged")
     override fun onClick(v: View?) {
         super.onClick(v)
@@ -108,7 +131,6 @@ class TripcourseActivity : BaseActivity(), PostCardView, ServerView {
                     "발자국 작성 취소", "발자국 작성을 취소하시겠습니까?\n"
                             + "작성중인 정보는 저장되지 않습니다.", "확인"
                 )
-                //todo Trip 삭제
             }
             R.id.topbar_subbutton_ib -> { //상단바 - 체크 버튼 - 저장
                 if( changedCards.isEmpty() ) {
@@ -154,7 +176,8 @@ class TripcourseActivity : BaseActivity(), PostCardView, ServerView {
         startActivity(intent)
     }
 
-    private fun addDefaultCard() {
+    private fun setDefaultCard() {
+        tripCards.clear()
         addCard()
         addCard()
         addCard()
@@ -216,8 +239,6 @@ class TripcourseActivity : BaseActivity(), PostCardView, ServerView {
             }
             changedCards.removeAt(0)
         }
-
-
 
         cardService.deleteTrip(tripIdx)
     }

--- a/app/src/main/java/com/olympos/tripbook/src/tripcourse/TripcourseRecordActivity.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/tripcourse/TripcourseRecordActivity.kt
@@ -182,11 +182,12 @@ class TripcourseRecordActivity : BaseActivity(), DateSelectDialog.DialogClickLis
 
     private fun getInputInfo() {
         //필수요소 : 제목
+        tripCards[focusedCardPosition].title = binding.tripcourseRecordTitleEt.text.toString()
+
         tripCards[focusedCardPosition].hasData = TRUE
         //사진 저장(Uri)
         tripCards[focusedCardPosition].imgUrl = firebaseUrl.toString()
-        //제목 저장
-        tripCards[focusedCardPosition].title = binding.tripcourseRecordTitleEt.text.toString()
+
         //body 저장
         tripCards[focusedCardPosition].body = binding.tripcourseRecordBodyEt.text.toString()
         //날짜 저장

--- a/app/src/main/java/com/olympos/tripbook/src/tripcourse/TripcourseRecordActivity.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/tripcourse/TripcourseRecordActivity.kt
@@ -176,7 +176,7 @@ class TripcourseRecordActivity : BaseActivity(), DateSelectDialog.DialogClickLis
 //            tripCards[focusedCardPosition]
 //        }
         if( beforeDate != tripCards[focusedCardPosition].date ){
-            tripCards[focusedCardPosition].date = tripDate
+            tripCards[focusedCardPosition].date = tripDate!!
         }
     }
 

--- a/app/src/main/java/com/olympos/tripbook/src/tripcourse/TripcourseRecordActivity.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/tripcourse/TripcourseRecordActivity.kt
@@ -24,7 +24,7 @@ import java.util.*
 class TripcourseRecordActivity : BaseActivity(), DateSelectDialog.DialogClickListener {
 
     lateinit var binding: ActivityTripcourseRecordBinding
-    lateinit var tripDate: String
+    private var tripDate: String? = null
 
     private var firebaseUrl: Uri? = null //firebase uri 전역변수
     private var localUrl: Uri? = null //local uri 전역변수
@@ -190,7 +190,9 @@ class TripcourseRecordActivity : BaseActivity(), DateSelectDialog.DialogClickLis
         //body 저장
         tripCards[focusedCardPosition].body = binding.tripcourseRecordBodyEt.text.toString()
         //날짜 저장
-        tripCards[focusedCardPosition].date = tripDate
+        if( tripDate != null ) {
+            tripCards[focusedCardPosition].date = tripDate!!
+        }
 
         //아직 구현이 안된 더미 데이터들
         tripCards[focusedCardPosition].time = 2

--- a/app/src/main/java/com/olympos/tripbook/src/tripcourse/model/Card.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/tripcourse/model/Card.kt
@@ -2,6 +2,7 @@ package com.olympos.tripbook.src.tripcourse.model
 
 
 import com.google.gson.annotations.SerializedName
+import com.olympos.tripbook.src.tripcourse.CARD_TITLE_NONE_DEFAULT
 import com.olympos.tripbook.src.tripcourse.FALSE
 
 data class Card (
@@ -15,7 +16,7 @@ data class Card (
     @SerializedName("courseImg") var imgUrl : String = "NONE",
     @SerializedName("courseDate") var date : String = "날짜를 선택해주세요",
     @SerializedName("courseTime") var time : Int = 2,
-    @SerializedName("courseTitle") var title : String = "NONE",
+    @SerializedName("courseTitle") var title : String = CARD_TITLE_NONE_DEFAULT,
     @SerializedName("courseComment")var body : String = "내용이 없습니다.",
 
     @SerializedName("latitude") var latitude : String? = null,
@@ -23,6 +24,4 @@ data class Card (
 //    @SerializedName("courseCountry")
 //    var country : String = "나도 모르는 곳",
 //    var hashtag : ArrayList<Boolean> = ArrayList(),
-
-    var whatsChange: ArrayList<Int> = ArrayList<Int>()
 )

--- a/app/src/main/java/com/olympos/tripbook/src/tripcourse/model/CardRetrofitInterface.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/tripcourse/model/CardRetrofitInterface.kt
@@ -14,8 +14,6 @@ interface CardRetrofitInterface {
     @PATCH("/app/trip/deleteTrip/{userIdx}/{tripIdx}")
     fun deleteTrip(@Path("userIdx") userIdx : Int, @Path("tripIdx") tripIdx: Int) : Call<ServerDefaultResponse>
 
-
-
     @PATCH("/app/course/deleteCourse/{userIdx}/{courseIdx}")
     fun deleteCard(@Path("userIdx") userIdx : Int, @Path("courseIdx") courseIdx :String) : Call<ServerDefaultResponse>
 
@@ -23,17 +21,17 @@ interface CardRetrofitInterface {
     fun getTripcourses(@Path("userIdx") userIdx: Int, @Path("tripIdx") tripIdx: String): Call<GetTripcourseResponse>
 
     @PATCH("/app/course/courseDate/{userIdx}/{courseIdx}")
-    fun patchDate(@Path("userIdx") userIdx : String, @Path("courseIdx") courseIdx :String, @Body params : HashMap<String, Any>) : Call<ServerDefaultResponse>
+    fun patchDate(@Path("userIdx") userIdx : Int, @Path("courseIdx") courseIdx :Int, @Body params : HashMap<String, Any>) : Call<ServerDefaultResponse>
 
     @PATCH("/app/course/courseTime/{userIdx}/{courseIdx}")
-    fun patchTime(@Path("userIdx") userIdx : String, @Path("courseIdx") courseIdx : String, @Body params : HashMap<String, Any>) : Call<ServerDefaultResponse>
+    fun patchTime(@Path("userIdx") userIdx : Int, @Path("courseIdx") courseIdx : Int, @Body params : HashMap<String, Any>) : Call<ServerDefaultResponse>
 
     @PATCH("/app/course/courseTitle/{userIdx}/{courseIdx}")
-    fun patchTitle(@Path("userIdx") userIdx : String, @Path("courseIdx") courseIdx:String, @Body params : HashMap<String, Any> ) : Call<ServerDefaultResponse>
+    fun patchTitle(@Path("userIdx") userIdx : Int, @Path("courseIdx") courseIdx:Int, @Body params : HashMap<String, Any> ) : Call<ServerDefaultResponse>
 
     @PATCH("/app/course/courseImg/{userIdx}/{courseIdx}")
-    fun patchImg(@Path("userIdx") userIdx : String, @Path("courseIdx") courseIdx:String, @Body params : HashMap<String, Any>) : Call<ServerDefaultResponse>
+    fun patchImg(@Path("userIdx") userIdx : Int, @Path("courseIdx") courseIdx:Int, @Body params : HashMap<String, Any>) : Call<ServerDefaultResponse>
 
     @PATCH("/app/course/courseComment/{userIdx}/{courseIdx}")
-    fun patchBody(@Path("userIdx") userIdx : String, @Path("courseIdx") courseIdx:String, @Body params : HashMap<String, Any>) : Call<ServerDefaultResponse>
+    fun patchBody(@Path("userIdx") userIdx : Int, @Path("courseIdx") courseIdx:Int, @Body params : HashMap<String, Any>) : Call<ServerDefaultResponse>
 }

--- a/app/src/main/java/com/olympos/tripbook/src/tripcourse/model/CardService.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/tripcourse/model/CardService.kt
@@ -190,11 +190,13 @@ class CardService{
 
     //카드 세부내용 올리기
     //작성 완료한 카드 서버로 전송
-    fun patchTitle(userIdx : String, courseIdx : String, title : String) {
+    fun patchTitle(courseIdx : Int, title : String) {
         Log.d("CheckPoint : ", "CardService-patchTitle Activated")
         serverView.onServerLoading()
         val params: HashMap<String, Any> = HashMap()
         params["courseTitle"] = title
+
+        val userIdx = getUserIdx()
 
         val cardRetrofitService = retrofit.create(CardRetrofitInterface::class.java)
         cardRetrofitService.patchTitle(userIdx, courseIdx, params).enqueue(object : Callback<ServerDefaultResponse> {
@@ -221,12 +223,14 @@ class CardService{
         })
     }
 
-    fun patchBody(userIdx : String, courseIdx : String, body : String) {
+    fun patchBody(courseIdx : Int, body : String) {
         Log.d("CheckPoint : ", "CardService-patchBody Activated")
         serverView.onServerLoading()
 
         val params: HashMap<String, Any> = HashMap()
         params["courseComment"] = body
+
+        val userIdx = getUserIdx()
 
         val cardRetrofitService = retrofit.create(CardRetrofitInterface::class.java)
         cardRetrofitService.patchBody(userIdx, courseIdx, params).enqueue(object : Callback<ServerDefaultResponse> {
@@ -253,12 +257,14 @@ class CardService{
         })
     }
 
-    fun patchImg(userIdx : String, courseIdx : String, img : String) {
+    fun patchImg(courseIdx : Int, img : String) {
         Log.d("CheckPoint : ", "CardService-patchImg Activated")
         serverView.onServerLoading()
 
         val params: HashMap<String, Any> = HashMap()
         params["courseImg"] = img
+
+        val userIdx = getUserIdx()
 
         val cardRetrofitService = retrofit.create(CardRetrofitInterface::class.java)
         cardRetrofitService.patchImg(userIdx, courseIdx, params).enqueue(object : Callback<ServerDefaultResponse> {
@@ -273,6 +279,40 @@ class CardService{
                         }
                         else -> { //의도된 실패
                             Log.d("CardService-patchImg", res.code.toString() + " : " + res.message)
+                            serverView.onServerFailure(res.code, res.message)
+                        }
+                    }
+                }
+            }
+            override fun onFailure(call: Call<ServerDefaultResponse>, t: Throwable) {
+                serverView.onServerFailure(400, t.message.toString())
+                Log.d("CardService-patchImg", t.toString()) //네트워크 실패
+            }
+        })
+    }
+
+    fun patchDate(courseIdx : Int, date : String) {
+        Log.d("CheckPoint : ", "CardService-patchImg Activated")
+        serverView.onServerLoading()
+
+        val params: HashMap<String, Any> = HashMap()
+        params["courseDate"] = date
+
+        val userIdx = getUserIdx()
+
+        val cardRetrofitService = retrofit.create(CardRetrofitInterface::class.java)
+        cardRetrofitService.patchDate(userIdx, courseIdx, params).enqueue(object : Callback<ServerDefaultResponse> {
+            override fun onResponse(call: Call<ServerDefaultResponse>, response: Response<ServerDefaultResponse>) {
+                if (response.isSuccessful) {
+                    val res = response.body()!!
+                    Log.d("__res", response.body()!!.toString())
+                    when (res.code) {
+                        1000 -> { //성공
+                            Log.d("CardService-patchDate", res.code.toString() + " : " + res.message)
+                            serverView.onServerSuccess()
+                        }
+                        else -> { //의도된 실패
+                            Log.d("CardService-patchDate", res.code.toString() + " : " + res.message)
                             serverView.onServerFailure(res.code, res.message)
                         }
                     }

--- a/app/src/main/java/com/olympos/tripbook/src/tripcourse/model/ConstantValues_tripcourse.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/tripcourse/model/ConstantValues_tripcourse.kt
@@ -24,4 +24,11 @@ const val BODY_CHANGED = 102
 const val IMG_CHANGED = 103
 const val DATE_CHANGED = 104
 
+const val CARD_TITLE_NONE_DEFAULT = "CARD_TITLE_NONE_DEFAULT"
 
+val changedCards = ArrayList<ChangedCardInfo>()
+
+data class ChangedCardInfo(
+    var changedCourseIdx: Int = 0,
+    val changedInfo: ArrayList<Int> = ArrayList<Int>()
+)

--- a/app/src/main/java/com/olympos/tripbook/src/tripcourse_view/TripcourseViewFragment.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/tripcourse_view/TripcourseViewFragment.kt
@@ -130,14 +130,13 @@ class TripcourseViewFragment : BaseFragment() , RecentTripResponseView, RecentTr
     override fun onGetRecentTripCardsSuccess(cards: ArrayList<Card>) {
         Log.d("ServerRecentTripCards", cards.toString())
         serverTripCards.clear()
+        filledCards.clear()
         serverTripCards.addAll(cards)
         for(i in 0 until serverTripCards.size) {
             if(serverTripCards[i].title != "NONE") {
-                Log.d("What's Happen in Here?", "i : $i, serverTripCards[i] = "+ serverTripCards[i].toString())
                 filledCards.add(serverTripCards[i])
             }
         }
-        Log.d("filledCards", filledCards.toString())
         cardRVAdapterView.notifyDataSetChanged()
     }
 

--- a/app/src/main/java/com/olympos/tripbook/src/tripcourse_view/model/ConstantValues_view.kt
+++ b/app/src/main/java/com/olympos/tripbook/src/tripcourse_view/model/ConstantValues_view.kt
@@ -10,4 +10,4 @@ var focusedViewCardPosition : Int = 0
 
 val filledCards = ArrayList<Card>()
 
-val serverTripCards = ArrayList<Card>()
+var serverTripCards = ArrayList<Card>()

--- a/app/src/main/res/layout/activity_tripcourse_record.xml
+++ b/app/src/main/res/layout/activity_tripcourse_record.xml
@@ -108,6 +108,7 @@
                         android:text="@string/tripcourse_record_country"
                         android:textColor="@color/black"
                         android:textSize="13sp"
+                        android:visibility="gone"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/activity_tripcourse_record.xml
+++ b/app/src/main/res/layout/activity_tripcourse_record.xml
@@ -136,9 +136,10 @@
 
                 <!--해시태그 선택(임시), 이후에 리사이클러뷰로 수정할 예정-->
                 <LinearLayout
+                    android:visibility="gone"
                     android:layout_width="match_parent"
                     android:layout_height="80dp"
-                    android:orientation="horizontal"
+                    android:orientation="vertical"
                     android:layout_marginTop="15dp">
 
                     <androidx.appcompat.widget.AppCompatButton
@@ -153,13 +154,15 @@
                         android:includeFontPadding="false"
                         android:layout_gravity="start|top"
                         android:paddingHorizontal="8dp" />
+
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:layout_marginTop="10dp"
+                        android:background="@color/gray" />
                 </LinearLayout>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:layout_marginTop="10dp"
-                    android:background="@color/gray" />
+
 
                 <LinearLayout
                     android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_tripcourse_record_view.xml
+++ b/app/src/main/res/layout/activity_tripcourse_record_view.xml
@@ -75,6 +75,7 @@
 
                     <!--여행 지역/도시 선택-->
                     <TextView
+                        android:visibility="gone"
                         android:id="@+id/tripcourse_record_view_select_country_btn"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -111,9 +112,10 @@
 
                 <!--해시태그 선택(임시), 이후에 리사이클러뷰로 수정할 예정-->
                 <LinearLayout
+                    android:visibility="gone"
                     android:layout_width="match_parent"
                     android:layout_height="80dp"
-                    android:orientation="horizontal"
+                    android:orientation="vertical"
                     android:layout_marginTop="15dp">
 
                     <androidx.appcompat.widget.AppCompatButton
@@ -128,13 +130,15 @@
                         android:includeFontPadding="false"
                         android:layout_gravity="start|top"
                         android:paddingHorizontal="8dp" />
+
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:layout_marginTop="10dp"
+                        android:background="@color/gray" />
                 </LinearLayout>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:layout_marginTop="10dp"
-                    android:background="@color/gray" />
+
 
                 <LinearLayout
                     android:layout_width="match_parent"


### PR DESCRIPTION
fix
메인화면에 카드가 쌓이는 에러 수정

Tripcourse
Tripcourse 수정 액티비티 기능, 화면 연결 (아직 서버에 수정은 안됨)
홈 화면에서 타이틀 길게 누르면 수정 화면으로 넘어갑니다.

Tripcourse 작성 중 뒤로가기를 누르면 post 되었던 Tripd을 삭제합니다

+ 사용하지 못하는 기능들은 우선 숨겨뒀습니다
+ Trip을 post하는 지점을 Tripcouse Post 지점으로 바꿔야 할 것 같습니다.